### PR TITLE
Fix travis

### DIFF
--- a/src/Particle.cpp
+++ b/src/Particle.cpp
@@ -496,7 +496,12 @@ double Particle::get_loglike(vector<double> &theta, int theta_i, bool quick_exit
 void Particle::update_region(int region_i) {
   
   //get thread index
+#ifdef _OPENMP
   int thread_idx = omp_get_thread_num();
+#else
+  int thread_idx = 0;
+#endif
+
   //print(thread_idx);
   
   // loop through sitrep age groups

--- a/src/Particle.cpp
+++ b/src/Particle.cpp
@@ -314,8 +314,10 @@ double Particle::get_loglike(vector<double> &theta, int theta_i, bool quick_exit
   // update objects used when calculating sitrep likelihood
   
   // loop through sitrep regions
+#ifdef _OPENMP
   const size_t n_threads = s_ptr->n_threads;
 #pragma omp parallel for schedule(static) num_threads(n_threads)
+#endif
   for (int region_i = 0; region_i < s_ptr->n_region; ++region_i) {
     update_region(region_i);
   }


### PR DESCRIPTION
This PR adds `#ifdef` guards around openmp-API calls and pragmas so that it will compile on travis' macOS systems.